### PR TITLE
Edit run_onchange_03-install-packages.tmpl: reduce number of times `chezmoi data` executes

### DIFF
--- a/home/run_onchange_03-install-packages.tmpl
+++ b/home/run_onchange_03-install-packages.tmpl
@@ -43,22 +43,18 @@ def install_packages(package_names):
     subprocess.run(command)
 
 
-def get_config():
+def get_packages_and_config():
     result = subprocess.run(["chezmoi", "data"], capture_output=True)
     data = json.loads(result.stdout)
-    return data["chezmoi"]["config"]["data"]
-
-
-def get_packages():
-    result = subprocess.run(["chezmoi", "data"], capture_output=True)
-    data = json.loads(result.stdout)
-    return data["packages"]
+    packages = data["packages"]
+    config = data["chezmoi"]["config"]["data"]
+    return packages, config
 
 
 def main():
-    packages = get_packages()
+    packages, config = get_packages_and_config()
     to_install = filter(not_installed, packages)
-    to_install = list(filter(lambda p: matches_features(p, get_config()), to_install))
+    to_install = list(filter(lambda p: matches_features(p, config), to_install))
     if to_install:
         install_packages(list(map(lambda p: p["name"], to_install)))
     else:


### PR DESCRIPTION
Claims I believe (each of which could be false and thereby make this commit wrong):
- each call to `get_config` returns the same information (i.e. for each call the return value is the same)
- `filter(lambda p: matches_features(p, get_config()), to_install)`, calls get_config() for each entry in `to_install`
- `get_packages` computes `data`, and `data` contains what `get_config` returns

Based on those claims, I propose:
 - `get_packages` returns both packages and config
 - in `filter(lambda p: matches_features(p, get_config()), to_install)`, replace `get_config()` with `config`, where `config` was computed once before and is reused for each package `p`